### PR TITLE
fix(docs): enable auto-deployment on Vercel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.21"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build all packages
+        run: bun run build
+
+      - name: Run tests
+        run: bun run test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,19 @@ Examples:
 - `feat(cli): add dry-run release summary`
 - `chore: refresh Bun workspace dependencies`
 
+### Commit regularly and split changes by concern
+
+- Commit early and often. Do not accumulate large diffs spanning multiple concerns into a single commit.
+- Each commit should represent one logical change: a single bug fix, a single feature addition, a single config update, or a single documentation change.
+- If a task involves changes to multiple subsystems (e.g., docs config, turbo config, CI pipeline), split them into separate commits with appropriate scopes.
+- Never mix unrelated changes in one commit. For example, do not combine a dependency update with a feature implementation.
+- Prefer small, reviewable commits over large monolithic ones.
+
+### Build and test before pushing
+
+- Run `bun run build` at the repo root before pushing to verify all packages compile.
+- Run `bun run test` to confirm existing tests pass.
+
 ### Before finishing work
 
 - If a PR already exists for your branch, verify its title is Conventional Commit compliant.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "fumadocs-mdx && next build",
     "dev": "next dev --turbo",
     "start": "next start",
     "postinstall": "fumadocs-mdx",

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd ../.. && bun run build:docs",
+  "installCommand": "cd ../.. && bun install",
+  "framework": "nextjs",
+  "outputDirectory": ".next"
+}

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,14 @@
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
+    "@nyron/cli#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "@nyron/bot#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["lib/**"]
+    },
     "lint": {},
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary

- Ensures `.source/` codegen runs before `next build` (not just in `postinstall` which Vercel may skip in monorepos)
- Adds `vercel.json` so deployment config is version-controlled instead of dashboard-only
- Fixes Turbo cache outputs for CLI (`dist/`) and bot (`lib/`) packages
- Adds GitHub Actions CI workflow to catch build failures before they hit Vercel
- Adds commit splitting and regular commit rules to `AGENTS.md`

## Post-merge: Verify Vercel dashboard settings

1. **Root Directory** → `apps/docs`
2. **Production Branch** → `master`
3. **Node.js Version** → `20.x`
4. Confirm GitHub repo connection is active

## Test plan

- [x] `bun run build:docs` succeeds locally (35 static pages generated)
- [x] `bun run test` passes (109 tests, 0 failures)
- [ ] After merge, push to master triggers Vercel auto-deploy
- [ ] Verify Vercel dashboard settings match the list above


🤖 Generated with [Claude Code](https://claude.com/claude-code)